### PR TITLE
Asynchronization and parallelization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cooked-waker"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147be55d677052dabc6b22252d5dd0fd4c29c8c27aa4f2fbef0f94aa003b406f"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,43 +283,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "deno-proc-macro-rules"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c65c2ffdafc1564565200967edc4851c7b55422d3913466688907efd05ea26f"
-dependencies = [
- "deno-proc-macro-rules-macros",
- "proc-macro2",
- "syn 2.0.28",
-]
-
-[[package]]
-name = "deno-proc-macro-rules-macros"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3047b312b7451e3190865713a4dd6e1f821aed614ada219766ebc3024a690435"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "deno_core"
-version = "0.222.0"
+version = "0.242.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13c81b9ea8462680e7b77088a44fc36390bab3dbfa5a205a285e11b64e0919c"
+checksum = "bce3947a74745927b2409b7d3533d7a9c06c7271c56a2e334cce9e431a7f6bfb"
 dependencies = [
  "anyhow",
+ "bit-set",
+ "bit-vec",
  "bytes",
+ "cooked-waker",
  "deno_ops",
  "deno_unsync",
  "futures",
- "indexmap",
  "libc",
  "log",
- "once_cell",
+ "memoffset",
  "parking_lot",
  "pin-project",
  "serde",
@@ -306,6 +306,7 @@ dependencies = [
  "serde_v8",
  "smallvec",
  "sourcemap",
+ "static_assertions",
  "tokio",
  "url",
  "v8",
@@ -313,18 +314,13 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.98.0"
+version = "0.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf89da1a3e50ff7c89956495b53d9bcad29e1f1b3f3d2bc54cad7155f55419c4"
+checksum = "a5a63b1ef458869727ad0c524fc1378a20038027fbb170a09730b5c763980f0b"
 dependencies = [
- "deno-proc-macro-rules",
- "lazy-regex",
- "once_cell",
- "pmutil",
- "proc-macro-crate",
+ "proc-macro-rules",
  "proc-macro2",
  "quote",
- "regex",
  "strum",
  "strum_macros",
  "syn 2.0.28",
@@ -333,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "deno_unsync"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a8f3722afd50e566ecfc783cc8a3a046bc4dd5eb45007431dfb2776aeb8993"
+checksum = "2e902f81b6d372427a99b65372379568e6350735562f3237c3daf61086e1d6e6"
 dependencies = [
  "tokio",
 ]
@@ -786,29 +782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy-regex"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e723bd417b2df60a0f6a2b6825f297ea04b245d4ba52b5a22cb679bdf58b05fa"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0a1d9139f0ee2e862e08a9c5d0ba0470f2aa21cd1e1aa1b1562f83116c725f"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +820,15 @@ name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1006,24 +988,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pmutil"
-version = "0.6.1"
+name = "proc-macro-rules"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
+checksum = "07c277e4e643ef00c1233393c673f655e3672cf7eb3ba08a00bdd0ea59139b5f"
 dependencies = [
+ "proc-macro-rules-macros",
  "proc-macro2",
- "quote",
  "syn 2.0.28",
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
+name = "proc-macro-rules-macros"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "207fffb0fe655d1d47f6af98cc2793405e85929bdbc420d685554ff07be27ac7"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1201,15 +1185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,15 +1209,14 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.131.0"
+version = "0.151.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cafa16d0a4288d75925351bb54d06d2e830118ad3fad393947bb11f91b18f3"
+checksum = "3f491e71da04e4ae2b178ea3572d40fce81ab760253437ccd3bd4a57a19a39e8"
 dependencies = [
  "bytes",
  "derive_more",
  "num-bigint",
  "serde",
- "serde_bytes",
  "smallvec",
  "thiserror",
  "v8",
@@ -1297,6 +1271,12 @@ dependencies = [
  "unicode-id",
  "url",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1428,23 +1408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,9 +1514,9 @@ checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 
 [[package]]
 name = "v8"
-version = "0.79.2"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15561535230812a1db89a696f1f16a12ae6c2c370c6b2241c68d4cb33963faf"
+checksum = "f53dfb242f4c0c39ed3fc7064378a342e57b5c9bd774636ad34ffe405b808121"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",
@@ -1776,12 +1739,3 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
-
-[[package]]
-name = "winnow"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
-dependencies = [
- "memchr",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "h2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +582,92 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http 1.0.0",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdea9aac0dbe5a9240d68cfd9501e2db94222c6dc06843e06640b9e07f0fdc67"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -754,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
@@ -1169,9 +1274,9 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1280,9 +1385,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1299,13 +1404,27 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.28",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1324,6 +1443,60 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-bidi"
@@ -1399,6 +1572,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,11 +1648,15 @@ dependencies = [
  "clap",
  "colored",
  "deno_core",
- "http",
+ "http 0.2.9",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "notify",
  "regex",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,11 @@ clap = { version = "4.3.21", features = ["color"] }
 colored = "2.0.4"
 deno_core = "0.222.0"
 http = "0.2.9"
+http-body-util = "0.1.0"
+hyper = { version = "1.1.0", features = ["full"] }
+hyper-util = { version = "0.1.2", features = ["full"] }
 notify = "6.1.1"
 regex = "1.10.1"
 serde = { version = "1.0.183", features = ["derive"]}
 serde_json = "1.0.104"
+tokio = { version = "1.35.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ repository = "https://github.com/webx-net/webx"
 chrono = "0.4.31"
 clap = { version = "4.3.21", features = ["color"] }
 colored = "2.0.4"
-deno_core = "0.222.0"
+deno_core = "0.242.0"
 http = "0.2.9"
 http-body-util = "0.1.0"
 hyper = { version = "1.1.0", features = ["full"] }
 hyper-util = { version = "0.1.2", features = ["full"] }
 notify = "6.1.1"
 regex = "1.10.1"
-serde = { version = "1.0.183", features = ["derive"]}
+serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.104"
 tokio = { version = "1.35.1", features = ["full"] }

--- a/examples/todo/index.wx
+++ b/examples/todo/index.wx
@@ -20,7 +20,11 @@ post list/all/(data : Int)/data json(a: T, b : U) -> renderAllTodos(todos, test)
 // This is an example WebX todo app project.
 global {
     // Global in-memory database of todos for this example.
-    const todos = [7, 3, 10];
+    const todos = [
+        { title: "Example Item", completed: true, createdAt: new Date().setMinutes(new Date().getMinutes() - 1) },
+        { title: "Example Item", completed: false, createdAt: new Date().setMinutes(new Date().getMinutes() - 3) },
+        { title: "Example Item", completed: false, createdAt: new Date().setMinutes(new Date().getMinutes() - 10) },
+    ];
     function test() { return todos[2]; }
     let a = test();
     console.log(a);

--- a/src/analysis/dependencies.rs
+++ b/src/analysis/dependencies.rs
@@ -17,7 +17,7 @@ type DependencyTree = HashMap<PathBuf, Vec<PathBuf>>;
 ///
 /// ## Returns
 /// The dependency tree.
-fn construct_dependency_tree(files: &Vec<WXModule>) -> DependencyTree {
+fn construct_dependency_tree(files: &[WXModule]) -> DependencyTree {
     let mut tree = DependencyTree::new();
     for file in files.iter() {
         // Insert dependencies into the tree as keys and the file path as the value.
@@ -33,7 +33,7 @@ fn construct_dependency_tree(files: &Vec<WXModule>) -> DependencyTree {
 
 fn detect_circular_dependencies(tree: &DependencyTree) -> Vec<PathBuf> {
     let mut circular_dependencies = Vec::new();
-    for (_, dependents) in tree {
+    for dependents in tree.values() {
         for dependent in dependents {
             if tree.contains_key(dependent) {
                 circular_dependencies.push(dependent.clone());
@@ -43,7 +43,7 @@ fn detect_circular_dependencies(tree: &DependencyTree) -> Vec<PathBuf> {
     circular_dependencies
 }
 
-fn analyse_circle_dependencies(modules: &Vec<WXModule>) {
+fn analyse_circle_dependencies(modules: &[WXModule]) {
     let dependency_tree = construct_dependency_tree(modules);
     let circular_dependencies = detect_circular_dependencies(&dependency_tree);
     if !circular_dependencies.is_empty() {
@@ -59,6 +59,6 @@ fn analyse_circle_dependencies(modules: &Vec<WXModule>) {
 
 /// Analyse the dependencies of a list of WebX modules.
 /// If a circular dependency is detected, an error is reported and the program exits.
-pub fn analyse_module_deps(modules: &Vec<WXModule>) {
+pub fn analyse_module_deps(modules: &[WXModule]) {
     analyse_circle_dependencies(modules);
 }

--- a/src/analysis/routes.rs
+++ b/src/analysis/routes.rs
@@ -78,8 +78,8 @@ fn extract_invalid_routes(routes: &FlatRoutes) -> Vec<String> {
     routes
         .iter()
         .filter(|((route, _), _)| match route.method {
-            http::Method::GET | http::Method::DELETE => route.body_format.is_some(),
-            http::Method::POST | http::Method::PUT => route.body_format.is_none(),
+            hyper::Method::GET | hyper::Method::DELETE => route.body_format.is_some(),
+            hyper::Method::POST | hyper::Method::PUT => route.body_format.is_none(),
             _ => false,
         })
         .map(|((route, path), info)| {

--- a/src/analysis/routes.rs
+++ b/src/analysis/routes.rs
@@ -30,7 +30,7 @@ fn flatten_scopes(
     }
 }
 
-pub fn extract_flat_routes(modules: &Vec<WXModule>) -> FlatRoutes {
+pub fn extract_flat_routes(modules: &[WXModule]) -> FlatRoutes {
     let mut routes = HashMap::new();
     for module in modules.iter() {
         flatten_scopes(
@@ -59,7 +59,7 @@ pub fn extract_duplicate_routes(routes: &FlatRoutes) -> Vec<String> {
         .collect()
 }
 
-pub fn analyse_duplicate_routes(modules: &Vec<WXModule>) -> Result<FlatRoutes, (String, i32)> {
+pub fn analyse_duplicate_routes(modules: &[WXModule]) -> Result<FlatRoutes, (String, i32)> {
     let routes = extract_flat_routes(modules);
     let duplicate_routes = extract_duplicate_routes(&routes);
     if !duplicate_routes.is_empty() {
@@ -98,7 +98,7 @@ fn extract_invalid_routes(routes: &FlatRoutes) -> Vec<String> {
 /// If an invalid route is detected, an error is reported and the program exits.
 /// Invalid routes include:
 /// - bad combinations of route methods and request body format types (e.g. GET + body)
-pub fn analyse_invalid_routes(modules: &Vec<WXModule>) -> Result<(), (String, i32)> {
+pub fn analyse_invalid_routes(modules: &[WXModule]) -> Result<(), (String, i32)> {
     let routes = extract_flat_routes(modules);
     let invalid_routes = extract_invalid_routes(&routes);
     if !invalid_routes.is_empty() {
@@ -119,12 +119,12 @@ fn exit_on_err<T>(result: Result<T, (String, i32)>) {
     }
 }
 
-pub fn analyse_module_routes(modules: &Vec<WXModule>) {
+pub fn analyse_module_routes(modules: &[WXModule]) {
     exit_on_err(analyse_duplicate_routes(modules));
     exit_on_err(analyse_invalid_routes(modules));
 }
 
-pub fn verify_model_routes(modules: &Vec<WXModule>) -> Result<FlatRoutes, (String, i32)> {
+pub fn verify_model_routes(modules: &[WXModule]) -> Result<FlatRoutes, (String, i32)> {
     let routes = analyse_duplicate_routes(modules)?;
     analyse_invalid_routes(modules)?;
     Ok(routes)

--- a/src/engine/filewatcher.rs
+++ b/src/engine/filewatcher.rs
@@ -1,0 +1,112 @@
+use notify::{self, Error, Event, Watcher};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::Sender;
+use std::time::{Duration, Instant};
+
+use crate::engine::runtime::WXRuntimeMessage;
+use crate::file::parser::parse_webx_file;
+use crate::file::webx::WXModulePath;
+use crate::reporting::debug::info;
+use crate::reporting::warning::warning;
+use crate::runner::WXMode;
+
+struct FSWEvent {
+    pub kind: notify::EventKind,
+    pub path: WXModulePath,
+    pub timestamp: Instant,
+    is_empty_state: bool,
+}
+
+impl FSWEvent {
+    fn new(kind: notify::EventKind, path: &Path) -> Self {
+        Self {
+            kind,
+            path: WXModulePath::new(path.to_path_buf()),
+            timestamp: Instant::now(),
+            is_empty_state: false,
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            kind: notify::EventKind::default(),
+            path: WXModulePath::new(PathBuf::default()),
+            timestamp: Instant::now(),
+            is_empty_state: true,
+        }
+    }
+
+    fn is_duplicate(&self, earlier: &Self) -> bool {
+        if self.is_empty_state || earlier.is_empty_state {
+            return false;
+        }
+        const EPSILON: u128 = 100; // ms
+        self.kind == earlier.kind
+            && self.path == earlier.path
+            && self.timestamp.duration_since(earlier.timestamp).as_millis() < EPSILON
+    }
+}
+
+pub struct WXFileWatcher {}
+
+impl WXFileWatcher {
+    /// Registers the file watcher thread
+    pub fn run(mode: WXMode, source_root: PathBuf, rt_tx: Sender<WXRuntimeMessage>) {
+        let mut last_event: FSWEvent = FSWEvent::empty();
+        let mut watcher = notify::recommended_watcher(move |res: Result<Event, Error>| {
+            match res {
+                Ok(event) => {
+                    match event.kind {
+                        notify::EventKind::Create(_) => {
+                            let event = FSWEvent::new(event.kind, &event.paths[0]);
+                            if !event.is_duplicate(&last_event) {
+                                match parse_webx_file(&event.path.inner) {
+                                    Ok(module) => {
+                                        rt_tx.send(WXRuntimeMessage::New(module)).unwrap()
+                                    }
+                                    Err(e) => {
+                                        warning(mode, format!("(FileWatcher) Error: {:?}", e))
+                                    }
+                                }
+                            }
+                            last_event = event; // Update last event
+                        }
+                        notify::EventKind::Modify(_) => {
+                            let event = FSWEvent::new(event.kind, &event.paths[0]);
+                            if !event.is_duplicate(&last_event) {
+                                match parse_webx_file(&event.path.inner) {
+                                    Ok(module) => rt_tx
+                                        .send(WXRuntimeMessage::Swap(event.path.clone(), module))
+                                        .unwrap(),
+                                    Err(e) => {
+                                        warning(mode, format!("(FileWatcher) Error: {:?}", e))
+                                    }
+                                }
+                            }
+                            last_event = event; // Update last event
+                        }
+                        notify::EventKind::Remove(_) => {
+                            let event = FSWEvent::new(event.kind, &event.paths[0]);
+                            if !event.is_duplicate(&last_event) {
+                                rt_tx
+                                    .send(WXRuntimeMessage::Remove(event.path.clone()))
+                                    .unwrap();
+                            }
+                            last_event = event; // Update last event
+                        }
+                        _ => (),
+                    }
+                }
+                Err(e) => warning(mode, format!("watch error: {:?}", e)),
+            }
+        })
+        .unwrap();
+        watcher
+            .watch(&source_root, notify::RecursiveMode::Recursive)
+            .unwrap();
+        info(mode, "Hot reloading is enabled.");
+        loop {
+            std::thread::sleep(Duration::from_millis(1000));
+        }
+    }
+}

--- a/src/engine/http.rs
+++ b/src/engine/http.rs
@@ -1,3 +1,25 @@
+pub mod requests {
+
+    use hyper::body::Incoming;
+
+    pub fn serialize(request: &hyper::Request<Incoming>) -> String {
+        let mut result = format!(
+            "{} {} {:?}\r\n",
+            request.method(),
+            request.uri(),
+            request.version()
+        );
+        for (header, value) in request.headers() {
+            result.push_str(&format!("{}: {}\r\n", header, value.to_str().unwrap_or("")));
+        }
+        if matches!(*request.method(), hyper::Method::POST | hyper::Method::PUT) {
+            result.push_str("\r\n");
+            result.push_str(&format!("{:?}", request.body()));
+        }
+        result
+    }
+}
+
 pub mod responses {
     use hyper::Response;
 

--- a/src/engine/http.rs
+++ b/src/engine/http.rs
@@ -1,76 +1,21 @@
-use std::{
-    io::{BufRead, BufReader, Read},
-    net::TcpStream,
-};
-
-use http::{request::Builder, Request, Response, Version};
-
-pub fn read_all_from_stream(stream: &TcpStream) -> String {
-    let mut reader = BufReader::new(stream);
-    let mut result = String::new();
-    reader.read_to_string(&mut result).unwrap_or(0);
-    result
-}
-
-pub fn parse_request_from_string<D: Default>(request: &str) -> Option<Request<D>> {
-    parse_request(BufReader::new(request.as_bytes()))
-}
-
-pub fn parse_request<D: Default, T: Read>(reader: BufReader<T>) -> Option<Request<D>> {
-    let mut lines = reader
-        .lines()
-        .map(|l| l.unwrap_or("".into()))
-        .take_while(|l| !l.is_empty());
-    let r = Request::builder();
-    let r = parse_request_line(lines.next()?, r)?;
-    let r = parse_request_headers(lines, r)?;
-    // let request = parse_http_request_body(reader)?;
-    let r = r.body(D::default()).unwrap();
-    Some(r)
-}
-
-fn parse_request_line(line: String, request: Builder) -> Option<Builder> {
-    let mut reqline = line.split_whitespace();
-    let method = reqline.next()?;
-    let path = reqline.next()?;
-    // Refrence:
-    // - https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages
-    // - https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP
-    let version = match reqline.next()? {
-        "HTTP/1.0" => Version::HTTP_10,
-        "HTTP/1.1" => Version::HTTP_11,
-        "HTTP/2.0" => Version::HTTP_2,
-        "HTTP/3.0" => Version::HTTP_3,
-        _ => Version::HTTP_09, // No version
-    };
-    Some(request.method(method).uri(path).version(version))
-}
-
-fn parse_request_headers(lines: impl Iterator<Item = String>, request: Builder) -> Option<Builder> {
-    let mut request = request;
-    for line in lines {
-        let mut header = line.splitn(2, ':');
-        request = request.header(header.next()?.trim(), header.next()?.trim());
-    }
-    Some(request)
-}
-
-pub fn serialize_response<D: Default + ToString>(response: &Response<D>) -> String {
-    let mut result = format!("HTTP/1.1 {}\r\n", response.status());
-    for (header, value) in response.headers() {
-        result.push_str(&format!("{}: {}\r\n", header, value.to_str().unwrap_or("")));
-    }
-    result.push_str("\r\n");
-    result.push_str(&response.body().to_string());
-    result
-}
-
 pub mod responses {
+    use hyper::Response;
+
     use crate::runner::WXMode;
 
-    pub fn ok_html(body: String) -> http::Response<String> {
-        http::Response::builder()
-            .status(http::StatusCode::OK)
+    pub fn serialize<D: Default + ToString>(response: &Response<D>) -> String {
+        let mut result = format!("HTTP/1.1 {}\r\n", response.status());
+        for (header, value) in response.headers() {
+            result.push_str(&format!("{}: {}\r\n", header, value.to_str().unwrap_or("")));
+        }
+        result.push_str("\r\n");
+        result.push_str(&response.body().to_string());
+        result
+    }
+
+    pub fn ok_html(body: String) -> Response<String> {
+        Response::builder()
+            .status(hyper::StatusCode::OK)
             .header("Access-Control-Allow-Origin", "*")
             .header("Content-Type", "text/html; charset=utf-8")
             .header("Content-Length", body.len().to_string())
@@ -84,7 +29,7 @@ pub mod responses {
             .unwrap()
     }
 
-    pub fn not_found_default_webx(mode: WXMode) -> http::Response<String> {
+    pub fn not_found_default_webx(mode: WXMode) -> Response<String> {
         let body = if mode.is_dev() {
             format!(
                 r#"<html>
@@ -114,8 +59,8 @@ pub mod responses {
 </html>"#
                 .to_string()
         };
-        http::Response::builder()
-            .status(http::StatusCode::NOT_FOUND)
+        Response::builder()
+            .status(hyper::StatusCode::NOT_FOUND)
             .header("Access-Control-Allow-Origin", "*")
             .header("Content-Type", "text/html; charset=utf-8")
             .header("Content-Length", body.len().to_string())
@@ -129,10 +74,7 @@ pub mod responses {
             .unwrap()
     }
 
-    pub fn internal_server_error_default_webx(
-        mode: WXMode,
-        message: String,
-    ) -> http::Response<String> {
+    pub fn internal_server_error_default_webx(mode: WXMode, message: String) -> Response<String> {
         let body = if mode.is_dev() {
             format!(
                 r#"<html>
@@ -176,8 +118,8 @@ pub mod responses {
 </html>"#
                 .to_string()
         };
-        http::Response::builder()
-            .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+        Response::builder()
+            .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
             .header("Access-Control-Allow-Origin", "*")
             .header("Content-Type", "text/html; charset=utf-8")
             .header("Content-Length", body.len().to_string())

--- a/src/engine/http.rs
+++ b/src/engine/http.rs
@@ -62,7 +62,7 @@ pub mod responses {
         <h1>404 Not Found</h1>
         <p>The requested URL was not found on this server.</p>
         <hr>
-        <address>webx/0.1.0 (Unix) (webx/{})</address>
+        <address>webx/{} development mode</address>
     </body>
 </html>"#,
                 env!("CARGO_PKG_VERSION")
@@ -76,7 +76,7 @@ pub mod responses {
         <h1>404 Not Found</h1>
         <p>The requested URL was not found on this server.</p>
         <hr>
-        <address>webx/0.1.0 (Unix)</address>
+        <address>webx</address>
     </body>
 </html>"#
                 .to_string()
@@ -135,7 +135,7 @@ pub mod responses {
             Either the server is overloaded or there is an error in the application.
         </p>
         <hr>
-        <address>webx prouction mode</address>
+        <address>webx</address>
     </body>
 </html>"#
                 .to_string()

--- a/src/engine/http.rs
+++ b/src/engine/http.rs
@@ -42,7 +42,7 @@ pub mod responses {
             .header("Content-Type", "text/html; charset=utf-8")
             .header("Content-Length", body.len().to_string())
             .header("Connection", "close")
-            .header("Server", "webx")
+            .header("Server", &format!("webx/{}", env!("CARGO_PKG_VERSION")))
             .header("Date", chrono::Utc::now().to_rfc2822())
             .header("Cache-Control", "no-cache")
             .header("Pragma", "no-cache")

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,3 +1,4 @@
+pub mod filewatcher;
 mod http;
 pub mod runtime;
 mod stdlib;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,5 +1,6 @@
 pub mod filewatcher;
 mod http;
 pub mod runtime;
+pub mod server;
 mod stdlib;
 mod test;

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -1,19 +1,18 @@
 use std::{
     borrow::Borrow,
-    cell::{Ref, RefCell, RefMut, UnsafeCell},
+    cell::{RefCell},
     collections::HashMap,
-    io::Write,
-    net::{SocketAddr, TcpStream},
+    net::{SocketAddr},
     path::Path,
     rc::Rc,
-    sync::{mpsc::Receiver, Arc, Mutex},
+    sync::{mpsc::Receiver},
 };
 
 use deno_core::{
     v8::{self, GetPropertyNamesArgs},
     JsRuntime,
 };
-use http::{Method, Uri};
+
 use hyper::service::service_fn;
 
 use crate::{

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -1,11 +1,6 @@
 use std::{
-    borrow::Borrow,
-    cell::{RefCell},
-    collections::HashMap,
-    net::{SocketAddr},
-    path::Path,
-    rc::Rc,
-    sync::{mpsc::Receiver},
+    borrow::Borrow, cell::RefCell, collections::HashMap, net::SocketAddr, path::Path, rc::Rc,
+    sync::mpsc::Receiver,
 };
 
 use deno_core::{

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -21,7 +21,10 @@ use crate::{
 };
 
 use super::{
-    http::responses::{self, ok_html},
+    http::{
+        requests,
+        responses::{self, ok_html},
+    },
     stdlib,
 };
 
@@ -753,10 +756,7 @@ impl WXRuntime {
     /// until the program is terminated.
     pub async fn run(&mut self) {
         self.recompile(); // Ensure that we have a valid route map.
-        if self.mode.is_dev() {
-            info(self.mode, "Dev mode enabled.");
-        }
-        // Multi-threading pool via asynchronous tokio.
+                          // TODO: Multi-threading pool via asynchronous tokio.
         let listener = tokio::net::TcpListener::bind(&self.addrs()[..])
             .await
             .unwrap();

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -810,8 +810,7 @@ impl WXRuntime {
                     rt.mode,
                     &format!("Response to: {}\n{}", addr, responses::serialize(&response)),
                 );
-            }
-            if rt.mode.debug_level().is_high() {
+            } else if rt.mode.debug_level().is_high() {
                 info(rt.mode, &format!("Response to: {}", addr));
             }
 

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -695,7 +695,7 @@ impl WXRuntime {
     /// ## Note
     /// This is **required** as `deno_core::JsRuntime` is **not** thread-safe
     /// and cannot be shared between threads.
-    pub async fn run(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pub fn run(&mut self) {
         self.recompile();
         loop {
             if let Ok(msg) = self.messages.recv() {

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -788,7 +788,10 @@ impl WXRuntime {
     ) -> Result<hyper::Response<String>, hyper::Error> {
         // let rt = rt.lock().unwrap();
         if rt.mode.debug_level().is_max() {
-            info(rt.mode, &format!("Request from: {}\n{:?}", addr, req));
+            info(
+                rt.mode,
+                &format!("Request from: {}\n{}", addr, requests::serialize(&req)),
+            );
         } else if rt.mode.debug_level().is_high() {
             info(rt.mode, &format!("Request from: {}", addr));
         }

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -345,9 +345,9 @@ impl WXRTRoute {
         assert!(self.body.is_some());
         let body = self.body.as_ref().unwrap();
         match body.body_type {
-            WXBodyType::TS => todo!("TS body type is not supported yet"),
+            WXBodyType::Ts => todo!("TS body type is not supported yet"),
             // TODO: Resolve bindings, render and execute JSX (dynamic)
-            WXBodyType::TSX => Ok(WXRTValue::String(body.body.clone())),
+            WXBodyType::Tsx => Ok(WXRTValue::String(body.body.clone())),
         }
     }
 
@@ -439,7 +439,7 @@ impl WXRouteMap {
     }
 
     /// Create a new route map from a list of modules.
-    fn from_modules(modules: &Vec<WXModule>) -> Result<Self, WXRuntimeError> {
+    fn from_modules(modules: &[WXModule]) -> Result<Self, WXRuntimeError> {
         let routes = verify_model_routes(modules);
         if let Err((message, code)) = routes {
             return Err(WXRuntimeError { code, message });

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -686,8 +686,18 @@ impl WXRuntime {
             .iter()
             .map(|port| SocketAddr::from(([127, 0, 0, 1], *port)))
             .collect::<Vec<_>>();
-        info(self.mode, &format!("WebX server is listening on: {}", ports.iter().map(|p| format!("http://localhost:{}", p)).collect::<Vec<_>>().join(", ")));
-        let listener = TcpListener::bind(&addrs[..]).unwrap();
+        info(
+            self.mode,
+            &format!(
+                "WebX server is listening on: {}",
+                ports
+                    .iter()
+                    .map(|p| format!("http://localhost:{}", p))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind(&addrs[..]).await.unwrap();
         // Don't block if in dev mode, wait and read hotswap messages.
         listener.set_nonblocking(self.mode.is_dev()).unwrap();
         loop {

--- a/src/engine/server.rs
+++ b/src/engine/server.rs
@@ -9,18 +9,24 @@ use hyper::{
 };
 use hyper_util::rt::TokioIo;
 
-use crate::{reporting::debug::info, runner::WXMode};
+use crate::{file::project::ProjectConfig, reporting::debug::info, runner::WXMode};
 
 use super::runtime::WXRuntimeMessage;
 
 /// The WebX web server.
 pub struct WXServer {
     mode: WXMode,
+    config: ProjectConfig,
+    runtime_tx: Sender<WXRuntimeMessage>,
 }
 
 impl WXServer {
-    pub fn new(mode: WXMode, rt_tx: Sender<WXRuntimeMessage>) -> Self {
-        WXServer { mode }
+    pub fn new(mode: WXMode, config: ProjectConfig, rt_tx: Sender<WXRuntimeMessage>) -> Self {
+        WXServer {
+            mode,
+            config,
+            runtime_tx: rt_tx,
+        }
     }
 
     fn ports(&self) -> Vec<u16> {

--- a/src/engine/server.rs
+++ b/src/engine/server.rs
@@ -80,8 +80,7 @@ impl WXServer {
     /// This is the main entry point for each connection to the server
     /// and simply passes the connection to the request handler `WXSvc` service.
     async fn serve(io: TokioIo<tokio::net::TcpStream>, svc: WXSvc) {
-        let res = http1::Builder::new().serve_connection(io, svc).await;
-        if let Err(err) = res {
+        if let Err(err) = http1::Builder::new().serve_connection(io, svc).await {
             eprintln!("failed to serve connection: {:?}", err);
         }
     }

--- a/src/engine/server.rs
+++ b/src/engine/server.rs
@@ -1,0 +1,114 @@
+use std::{future::Future, net::SocketAddr, pin::Pin};
+
+use http_body_util::Full;
+use hyper::{
+    body::{Bytes, Incoming},
+    server::conn::http1,
+    service::Service,
+    Request, Response,
+};
+use hyper_util::rt::TokioIo;
+
+use crate::{reporting::debug::info, runner::WXMode};
+
+/// The WebX web server.
+pub struct WXServer {
+    mode: WXMode,
+}
+
+impl WXServer {
+    pub fn new(mode: WXMode) -> Self {
+        WXServer { mode }
+    }
+
+    fn ports(&self) -> Vec<u16> {
+        if self.mode.is_dev() {
+            vec![8080]
+        } else {
+            vec![80, 443]
+        }
+    }
+
+    fn addrs(&self) -> Vec<std::net::SocketAddr> {
+        self.ports()
+            .iter()
+            .map(|port| SocketAddr::from(([127, 0, 0, 1], *port)))
+            .collect::<Vec<_>>()
+    }
+
+    fn log_startup(&mut self) {
+        info(
+            self.mode,
+            &format!(
+                "WebX server is listening on: {}",
+                self.ports()
+                    .iter()
+                    .map(|p| format!("http://localhost:{}", p))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        );
+    }
+
+    /// Starts the WebX web server and listens for incoming requests in its own thread.
+    pub async fn run(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let listener = tokio::net::TcpListener::bind(&self.addrs()[..]).await?;
+        let svc = WXSvc::new();
+        self.log_startup();
+        loop {
+            let (stream, _) = listener.accept().await?;
+            let io = TokioIo::new(stream);
+            // TODO: Multi-threading pool via asynchronous workers and tokio.
+            tokio::task::spawn(Self::serve(io, svc.clone()));
+        }
+    }
+
+    /// Serves a single connection.
+    /// This is the main entry point for each connection to the server
+    /// and simply passes the connection to the request handler `WXSvc` service.
+    async fn serve(io: TokioIo<tokio::net::TcpStream>, svc: WXSvc) {
+        let res = http1::Builder::new().serve_connection(io, svc).await;
+        if let Err(err) = res {
+            eprintln!("failed to serve connection: {:?}", err);
+        }
+    }
+}
+
+/// The WebX server context.
+/// This is the context that is passed to each request handler.
+///
+/// Reference implementation: https://github.com/hyperium/hyper/blob/master/examples/service_struct_impl.rs
+#[derive(Clone, Debug)]
+struct WXSvc {}
+
+impl WXSvc {
+    pub fn new() -> Self {
+        WXSvc {}
+    }
+
+    fn ok(&self, text: String) -> Result<Response<Full<Bytes>>, hyper::Error> {
+        Ok(Response::new(Full::new(Bytes::from(text))))
+    }
+}
+
+impl Service<Request<Incoming>> for WXSvc {
+    type Response = Response<Full<Bytes>>;
+    type Error = hyper::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    /// The WebX server request handler.
+    /// This is the main entry point for all requests.
+    /// It is responsible for routing requests to the appropriate handler.
+    /// It is also responsible for error handling, logging, etc.
+    ///
+    /// ## Note
+    /// - Called for each request.
+    /// - Runs in a separate "thread"/tokio task.
+    /// - It is asynchronous.
+    /// - Respond back to the client.
+    ///
+    /// But most importantly, it will communicate with the WebX engine and runtimes.
+    fn call(&self, _req: Request<Incoming>) -> Self::Future {
+        let res = self.ok("Hello world from hyper service!".to_string());
+        Box::pin(async move { res })
+    }

--- a/src/engine/server.rs
+++ b/src/engine/server.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, net::SocketAddr, pin::Pin};
+use std::{future::Future, net::SocketAddr, pin::Pin, sync::mpsc::Sender};
 
 use http_body_util::Full;
 use hyper::{
@@ -11,13 +11,15 @@ use hyper_util::rt::TokioIo;
 
 use crate::{reporting::debug::info, runner::WXMode};
 
+use super::runtime::WXRuntimeMessage;
+
 /// The WebX web server.
 pub struct WXServer {
     mode: WXMode,
 }
 
 impl WXServer {
-    pub fn new(mode: WXMode) -> Self {
+    pub fn new(mode: WXMode, rt_tx: Sender<WXRuntimeMessage>) -> Self {
         WXServer { mode }
     }
 

--- a/src/engine/stdlib.rs
+++ b/src/engine/stdlib.rs
@@ -30,7 +30,7 @@ fn webx_static(
 
 pub fn try_call(
     name: &str,
-    args: &Vec<WXRTValue>,
+    args: &[WXRTValue],
     info: &WXRuntimeInfo,
 ) -> Option<Result<WXRTValue, WXRuntimeError>> {
     let assert_args = |n: usize| {

--- a/src/engine/stdlib.rs
+++ b/src/engine/stdlib.rs
@@ -35,18 +35,18 @@ pub fn try_call(
 ) -> Option<Result<WXRTValue, WXRuntimeError>> {
     let assert_args = |n: usize| {
         if args.len() != n {
-            return Some(Err::<WXRTValue, WXRuntimeError>(WXRuntimeError {
+            return Some(WXRuntimeError {
                 message: format!("{}: expected {} arguments, got {}", name, n, args.len()),
                 code: ERROR_HANDLER_CALL,
-            }));
+            });
         }
         None
     };
 
     match name {
         "static" => Some(match assert_args(1) {
-            Some(err) => err,
             None => webx_static(&args[0], info),
+            Some(err) => Err(err),
         }),
         _ => None,
     }

--- a/src/engine/test.rs
+++ b/src/engine/test.rs
@@ -31,14 +31,22 @@ mod tests {
             std::thread::spawn(move || {
                 let mut runtime = WXRuntime::new(dummy_rx, mode, WXRuntimeInfo::new(root));
                 runtime.load_modules(webx_modules);
-                runtime.run();
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap()
+                    .block_on(runtime.run());
             });
             std::thread::sleep(std::time::Duration::from_secs(TIMEOUT));
             std::process::exit(0);
         } else {
             let mut runtime = WXRuntime::new(dummy_rx, mode, WXRuntimeInfo::new(root));
             runtime.load_modules(webx_modules);
-            runtime.run();
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(runtime.run());
         }
     }
 }

--- a/src/engine/test.rs
+++ b/src/engine/test.rs
@@ -31,22 +31,14 @@ mod tests {
             std::thread::spawn(move || {
                 let mut runtime = WXRuntime::new(dummy_rx, mode, WXRuntimeInfo::new(root));
                 runtime.load_modules(webx_modules);
-                tokio::runtime::Builder::new_multi_thread()
-                    .enable_all()
-                    .build()
-                    .unwrap()
-                    .block_on(runtime.run());
+                runtime.run()
             });
             std::thread::sleep(std::time::Duration::from_secs(TIMEOUT));
             std::process::exit(0);
         } else {
             let mut runtime = WXRuntime::new(dummy_rx, mode, WXRuntimeInfo::new(root));
             runtime.load_modules(webx_modules);
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(runtime.run());
+            runtime.run()
         }
     }
 }

--- a/src/file/parser.rs
+++ b/src/file/parser.rs
@@ -741,7 +741,7 @@ impl<'a> WebXFileParser<'a> {
     ///     // ...
     /// }
     /// ```
-    fn parse_route(&mut self, method: http::Method) -> Result<WXRoute, String> {
+    fn parse_route(&mut self, method: hyper::Method) -> Result<WXRoute, String> {
         Ok(WXRoute {
             info: WXInfoField {
                 path: WXModulePath::new(self.file.clone()),
@@ -819,7 +819,7 @@ impl<'a> WebXFileParser<'a> {
                     }
                     'e' => {
                         self.expect_specific_str("head", 2, context);
-                        scope.routes.push(self.parse_route(http::Method::HEAD)?);
+                        scope.routes.push(self.parse_route(hyper::Method::HEAD)?);
                     }
                     c => exit_error_expected_any_of_but_found(
                         "handler or head".to_string(),
@@ -833,7 +833,7 @@ impl<'a> WebXFileParser<'a> {
                 'g' => match self.expect(context) {
                     'e' => {
                         self.expect_specific_str("get", 2, context);
-                        scope.routes.push(self.parse_route(http::Method::GET)?);
+                        scope.routes.push(self.parse_route(hyper::Method::GET)?);
                     }
                     'l' => {
                         self.expect_specific_str("global", 2, context);
@@ -853,15 +853,15 @@ impl<'a> WebXFileParser<'a> {
                 'p' => match self.expect(context) {
                     'o' => {
                         self.expect_specific_str("post", 2, context);
-                        scope.routes.push(self.parse_route(http::Method::POST)?);
+                        scope.routes.push(self.parse_route(hyper::Method::POST)?);
                     }
                     'u' => {
                         self.expect_specific_str("put", 2, context);
-                        scope.routes.push(self.parse_route(http::Method::PUT)?);
+                        scope.routes.push(self.parse_route(hyper::Method::PUT)?);
                     }
                     'a' => {
                         self.expect_specific_str("patch", 2, context);
-                        scope.routes.push(self.parse_route(http::Method::PATCH)?);
+                        scope.routes.push(self.parse_route(hyper::Method::PATCH)?);
                     }
                     c => exit_error_expected_any_of_but_found(
                         "post, put or patch".to_string(),
@@ -874,19 +874,19 @@ impl<'a> WebXFileParser<'a> {
                 },
                 'd' => {
                     self.expect_specific_str("delete", 1, context);
-                    scope.routes.push(self.parse_route(http::Method::DELETE)?);
+                    scope.routes.push(self.parse_route(hyper::Method::DELETE)?);
                 }
                 'c' => {
                     self.expect_specific_str("connect", 1, context);
-                    scope.routes.push(self.parse_route(http::Method::CONNECT)?);
+                    scope.routes.push(self.parse_route(hyper::Method::CONNECT)?);
                 }
                 'o' => {
                     self.expect_specific_str("options", 1, context);
-                    scope.routes.push(self.parse_route(http::Method::OPTIONS)?);
+                    scope.routes.push(self.parse_route(hyper::Method::OPTIONS)?);
                 }
                 't' => {
                     self.expect_specific_str("trace", 1, context);
-                    scope.routes.push(self.parse_route(http::Method::TRACE)?);
+                    scope.routes.push(self.parse_route(hyper::Method::TRACE)?);
                 }
                 _ => exit_error_unexpected_char(c, context, self.line, self.column, ERROR_SYNTAX),
             }

--- a/src/file/parser.rs
+++ b/src/file/parser.rs
@@ -534,14 +534,14 @@ impl<'a> WebXFileParser<'a> {
             Some('{') => {
                 self.next();
                 Some(WXBody {
-                    body_type: WXBodyType::TS,
+                    body_type: WXBodyType::Ts,
                     body: Self::de_indent_block(self.parse_block('{', '}')),
                 })
             }
             Some('(') => {
                 self.next();
                 Some(WXBody {
-                    body_type: WXBodyType::TSX,
+                    body_type: WXBodyType::Tsx,
                     body: Self::de_indent_block(self.parse_block('(', ')')),
                 })
             }

--- a/src/file/project.rs
+++ b/src/file/project.rs
@@ -204,7 +204,7 @@ pub fn load_modules(src: &Path) -> Vec<WXModule> {
 /// If a `webx.config.json` file already exists in the root directory,
 /// and `override_existing` is set to `false`, then a warning is printed and
 /// the function returns.
-pub fn create_new_project(mode: WXMode, name: String, root_dir: &PathBuf, override_existing: bool) {
+pub fn create_new_project(mode: WXMode, name: String, root_dir: &Path, override_existing: bool) {
     let root_dir = root_dir.to_path_buf().join(&name);
     let config_file = root_dir.join("webx.config.json");
     let src_dir = root_dir.join("webx");

--- a/src/file/webx.rs
+++ b/src/file/webx.rs
@@ -320,7 +320,7 @@ impl fmt::Debug for WXRouteHandler {
 pub struct WXRoute {
     pub info: WXInfoField,
     /// HTTP method of the route.
-    pub method: http::Method,
+    pub method: hyper::Method,
     /// The path of the route.
     pub path: WXUrlPath,
     /// Request body format.

--- a/src/file/webx.rs
+++ b/src/file/webx.rs
@@ -97,7 +97,7 @@ pub const WXROOT_PATH: WXUrlPath = WXUrlPath(vec![]);
 
 /// # WebX module
 /// A file data structure for WebX files.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WXModule {
     /// The path to the file.
     pub path: WXModulePath,

--- a/src/file/webx.rs
+++ b/src/file/webx.rs
@@ -191,16 +191,16 @@ pub struct WXHandler {
 
 #[derive(Hash, PartialEq, Eq, Clone)]
 pub enum WXBodyType {
-    TS,
-    TSX,
+    Ts,
+    Tsx,
     // TODO: JSON and TEXT
 }
 
 impl ToString for WXBodyType {
     fn to_string(&self) -> String {
         match self {
-            WXBodyType::TS => "ts".to_string(),
-            WXBodyType::TSX => "tsx".to_string(),
+            WXBodyType::Ts => "ts".to_string(),
+            WXBodyType::Tsx => "tsx".to_string(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn cli() -> Command {
             info = "{name} {version}".bright_white(),
             author = "Created by {author}".italic().bright_black()
         ))
-        .after_help(format!("{}", "For more information, visit: https://github.com/WilliamRagstad/webx.".bright_black()))
+        .after_help(format!("{}{}", "More information on ".bright_black(), env!("CARGO_PKG_HOMEPAGE").bright_black()))
 }
 
 fn parse_debug_level(matches: &clap::ArgMatches) -> DebugLevel {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -222,7 +222,11 @@ pub fn run(root: &Path, mode: WXMode) {
         let runtime_hnd = std::thread::spawn(move || {
             let mut runtime = WXRuntime::new(rt_rx, mode, info);
             runtime.load_modules(webx_modules);
-            runtime.run();
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(runtime.run());
         });
         runtime_hnd.join().unwrap();
         fw_hnd.join().unwrap();
@@ -230,7 +234,11 @@ pub fn run(root: &Path, mode: WXMode) {
         // If we are in production mode, run in main thread.
         let mut runtime = WXRuntime::new(rt_rx, mode, WXRuntimeInfo::new(root));
         runtime.load_modules(webx_modules);
-        runtime.run();
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(runtime.run());
     }
     // Check ps info: `ps | ? ProcessName -eq "webx"`
     // On interrupt, all threads are also terminated

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -211,6 +211,8 @@ pub fn run(root: &Path, mode: WXMode) {
     analyse_module_deps(&webx_modules);
     analyse_module_routes(&webx_modules);
     print_start_info(&webx_modules, mode, &config, time_start.elapsed());
+
+    // Setup and start all threads
     let (rt_tx, rt_rx) = std::sync::mpsc::channel();
     if mode.is_dev() {
         let fw_rt_tx = rt_tx.clone();
@@ -228,9 +230,7 @@ pub fn run(root: &Path, mode: WXMode) {
         });
         let sv_rt_tx = rt_tx.clone();
         let server_hnd = std::thread::spawn(move || {
-            // let server = WXServer::new(mode, config, rt_tx);
-            // server.run();
-            let mut server = WXServer::new(mode, sv_rt_tx);
+            let mut server = WXServer::new(mode, config, sv_rt_tx);
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()
@@ -256,7 +256,7 @@ pub fn run(root: &Path, mode: WXMode) {
                 .unwrap();
         });
         let sv_rt_tx = rt_tx.clone();
-        let mut server = WXServer::new(mode, sv_rt_tx);
+        let mut server = WXServer::new(mode, config, sv_rt_tx);
         tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -226,12 +226,7 @@ pub fn run(root: &Path, mode: WXMode) {
         let runtime_hnd = std::thread::spawn(move || {
             let mut runtime = WXRuntime::new(rt_rx, mode, info);
             runtime.load_modules(webx_modules);
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(runtime.run())
-                .unwrap();
+            runtime.run()
         });
         let sv_rt_tx = rt_tx.clone();
         let server_hnd = std::thread::spawn(move || {
@@ -248,12 +243,7 @@ pub fn run(root: &Path, mode: WXMode) {
         let runtime_hnd = std::thread::spawn(move || {
             let mut runtime = WXRuntime::new(rt_rx, mode, info);
             runtime.load_modules(webx_modules);
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(runtime.run())
-                .unwrap();
+            runtime.run()
         });
         let sv_rt_tx = rt_tx.clone();
         let mut server = WXServer::new(mode, config, sv_rt_tx);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use crate::analysis::{dependencies::analyse_module_deps, routes::analyse_module_routes};
 use crate::engine::filewatcher::WXFileWatcher;
 use crate::engine::runtime::{WXRuntime, WXRuntimeInfo};
-use crate::engine::server::{self, WXServer};
+use crate::engine::server::WXServer;
 use crate::file::project::{load_modules, load_project_config, ProjectConfig};
 use crate::file::webx::WXModule;
 use crate::reporting::error::{exit_error_hint, ERROR_PROJECT};

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -45,24 +45,15 @@ impl DebugLevel {
     }
 
     pub fn is_medium(&self) -> bool {
-        match self {
-            Self::Medium | Self::High | Self::Max => true,
-            _ => false,
-        }
+        matches!(self, Self::Medium | Self::High | Self::Max)
     }
 
     pub fn is_high(&self) -> bool {
-        match self {
-            Self::High | Self::Max => true,
-            _ => false,
-        }
+        matches!(self, Self::High | Self::Max)
     }
 
     pub fn is_max(&self) -> bool {
-        match self {
-            Self::Max => true,
-            _ => false,
-        }
+        matches!(self, Self::Max)
     }
 
     pub fn name(&self) -> &str {
@@ -111,7 +102,7 @@ impl PartialEq<WXMode> for WXMode {
 }
 
 fn print_start_info(
-    modules: &Vec<WXModule>,
+    modules: &[WXModule],
     mode: WXMode,
     config: &ProjectConfig,
     start_duration: std::time::Duration,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -252,10 +252,10 @@ struct FSWEvent {
 }
 
 impl FSWEvent {
-    fn new(kind: notify::EventKind, path: &PathBuf) -> Self {
+    fn new(kind: notify::EventKind, path: &Path) -> Self {
         Self {
             kind,
-            path: WXModulePath::new(path.clone()),
+            path: WXModulePath::new(path.to_path_buf()),
             timestamp: Instant::now(),
             is_empty_state: false,
         }
@@ -282,7 +282,7 @@ impl FSWEvent {
 }
 
 /// Registers the file watcher thread
-fn run_filewatcher(mode: WXMode, source_root: &PathBuf, rt_tx: Sender<WXRuntimeMessage>) {
+fn run_filewatcher(mode: WXMode, source_root: &Path, rt_tx: Sender<WXRuntimeMessage>) {
     let mut last_event: FSWEvent = FSWEvent::empty();
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, Error>| {
         match res {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -216,8 +216,7 @@ pub fn run(root: &Path, mode: WXMode) {
     print_start_info(&webx_modules, mode, &config, time_start.elapsed());
     let (rt_tx, rt_rx) = std::sync::mpsc::channel();
     if mode.is_dev() {
-        let fw_rt_tx = rt_tx.clone();
-        let fw_hnd = std::thread::spawn(move || run_filewatcher(mode, &source_root, fw_rt_tx));
+        let fw_hnd = std::thread::spawn(move || run_filewatcher(mode, &source_root, rt_tx.clone()));
         let info = WXRuntimeInfo::new(root);
         let runtime_hnd = std::thread::spawn(move || {
             let mut runtime = WXRuntime::new(rt_rx, mode, info);


### PR DESCRIPTION
Using inspiration from the actor model, we can safely share a mutable reference to a **thread-unsafe** instance of `deno_code::JsRuntime` between our web servers' asynchronous handler functions running as `Future` tasks in tokio threads.
The achieved architecture looks like the following:

```mermaid
graph TB
    A["Main (Thread)"]
    Dev["Dev Mode Features (Thread)"]
    subgraph Tokio["Tokio Runtime (Thread Pool)"]
    	W["Web Server"]
        C["Worker 1"]
        D["Worker 2"]
        E["Worker N"]
    end
    F["JS Runtime Manager (Thread + Singleton)"]

    A -->|"Starts"| F
    A -->|"Starts"| W
    A -.->|"Starts"| Dev
    W -->|"Starts"| C
    W -->|"Starts"| D
    W -->|"Starts"| E
    C -->|"Accesses"| F
    D -->|"Accesses"| F
    E -->|"Accesses"| F
    Dev -.->|"Accesses"| F

    style Tokio fill:#803037
```

## Closes
- #2 
- #1 
