### PR TITLE
Internal JavaScript values only

### DIFF
--- a/examples/todo/index.html
+++ b/examples/todo/index.html
@@ -5,7 +5,6 @@
 	<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 	<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 	<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-	<link rel="manifest" href="/site.webmanifest">
 	<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 	<meta name="msapplication-TileColor" content="#ffffff">
 	<meta name="theme-color" content="#ffffff">

--- a/examples/todo/index.wx
+++ b/examples/todo/index.wx
@@ -13,6 +13,12 @@ get / (<html>
     </body>
 </html>)
 
+get /about (<div>
+    <h1>About</h1>
+    <p>This is an example WebX project.</p>
+    <a href="/">Home</a>
+</div>)
+
 post /about/(id: Num) form(text: String) -> renderAllTodos(a, b): c {
     const a = [5];
     if true { console.log(text); }
@@ -57,12 +63,6 @@ handler authenticate(user_id: Number) {
         return Guard::Deny;
     }
 }
-
-get /about (<div>
-    <h1>About</h1>
-    <p>This is an example WebX project.</p>
-    <a href="/">Home</a>
-</div>)
 
 location todos {
     // The main todo app page.

--- a/examples/todo/index.wx
+++ b/examples/todo/index.wx
@@ -1,6 +1,6 @@
 /* import { Todo, renderAllTodos, renderTodo } from "./todos"; */
 
-get /(asset: String) -> static("assets/" + asset)
+get /public/(asset: String) -> static("assets/" + asset)
 
 get / (<html>
     <body>

--- a/src/engine/http.rs
+++ b/src/engine/http.rs
@@ -25,24 +25,19 @@ pub mod responses {
 
     use crate::runner::WXMode;
 
-    pub const HEADER_SERVER: String = format!("webx/{}", env!("CARGO_PKG_VERSION"));
-    pub const HEADER_SERVER_RELEASE: &str = "webx";
-    pub const SERVER_BANNER: String = format!("{} development mode", HEADER_SERVER);
-    pub const SERVER_BANNER_RELEASE: &str = HEADER_SERVER_RELEASE;
-
     pub fn server_header(mode: WXMode) -> String {
         if mode.is_dev() {
-            HEADER_SERVER.clone()
+            format!("webx/{}", env!("CARGO_PKG_VERSION"))
         } else {
-            HEADER_SERVER_RELEASE.to_string()
+            "webx".to_string()
         }
     }
 
     pub fn server_banner(mode: WXMode) -> String {
         if mode.is_dev() {
-            SERVER_BANNER.clone()
+            format!("{} development mode", server_header(mode))
         } else {
-            SERVER_BANNER_RELEASE.to_string()
+            "webx".to_string()
         }
     }
 

--- a/src/engine/http.rs
+++ b/src/engine/http.rs
@@ -35,12 +35,12 @@ pub mod responses {
         result
     }
 
-    pub fn ok_html(body: String) -> Response<String> {
+    pub fn ok_html<T>(body: T, len: usize) -> Response<T> {
         Response::builder()
             .status(hyper::StatusCode::OK)
             .header("Access-Control-Allow-Origin", "*")
             .header("Content-Type", "text/html; charset=utf-8")
-            .header("Content-Length", body.len().to_string())
+            .header("Content-Length", len.to_string())
             .header("Connection", "close")
             .header("Server", &format!("webx/{}", env!("CARGO_PKG_VERSION")))
             .header("Date", chrono::Utc::now().to_rfc2822())

--- a/src/engine/http.rs
+++ b/src/engine/http.rs
@@ -113,11 +113,8 @@ pub mod responses {
         <address>{}</address>
     </body>
 </html>"#,
-            if message.is_empty() {
-                ""
-            } else {
-                &format!(
-                    r#"
+            format!(
+                r#"
         <h2>Debugging Information</h2>
         <p>
             <strong>Message:</strong>
@@ -125,9 +122,8 @@ pub mod responses {
 {}
             </pre>
         </p>"#,
-                    message
-                )
-            },
+                message
+            ),
             server_banner(mode)
         );
         Response::builder()

--- a/src/engine/http.rs
+++ b/src/engine/http.rs
@@ -72,6 +72,26 @@ pub mod responses {
             .unwrap()
     }
 
+    pub fn ok_json(body: &Global<Value>, scope: &mut HandleScope, mode: WXMode) -> Response<Bytes> {
+        let local = Local::new(scope, body);
+        let value = v8::json::stringify(scope, local).expect("Failed to serialize JSON value");
+        let json = value.to_rust_string_lossy(scope);
+        let bytes = Bytes::from(json);
+        Response::builder()
+            .status(hyper::StatusCode::OK)
+            .header("Access-Control-Allow-Origin", "*")
+            .header("Content-Type", "application/json")
+            .header("Content-Length", bytes.len().to_string())
+            .header("Connection", "close")
+            .header("Server", server_header(mode))
+            .header("Date", chrono::Utc::now().to_rfc2822())
+            .header("Cache-Control", "no-cache")
+            .header("Pragma", "no-cache")
+            .header("Expires", "0")
+            .body(bytes)
+            .unwrap()
+    }
+
     pub fn not_found_default_webx(mode: WXMode) -> Response<String> {
         let body = format!(
             r#"<html>

--- a/src/engine/runtime.rs
+++ b/src/engine/runtime.rs
@@ -390,7 +390,10 @@ impl WXRTRoute {
                 &mut rt.handle_scope(),
                 mode,
             )),
-            (_, _, _) => todo!("Route execution not implemented"),
+            (_, _, _) => Err(WXRuntimeError {
+                code: 500,
+                message: format!("Route execution not implemented for: pre_handlers={}, body={}, post_handlers={}", has_pre_handlers, has_body, has_post_handlers),
+            }),
         };
         // if !has_pre_handlers && !has_body && !has_post_handlers {
         //     // No handlers or body are present, return an empty response.

--- a/src/engine/stdlib.rs
+++ b/src/engine/stdlib.rs
@@ -68,15 +68,15 @@ pub fn try_call(
 //     Ok(file)
 // }
 
-pub fn init() -> Extension {
-    Extension {
-        name: "webx stdlib",
-        ops: vec![].into(), //  vec![op_webx_static::decl()],
-        esm_files: include_js_files!(stdlib "src/engine/stdlib.js",)
-            .to_vec()
-            .into(),
-        ..Default::default()
-    }
-}
+// pub fn init() -> Extension {
+//     Extension {
+//         name: "webx stdlib",
+//         ops: vec![].into(), //  vec![op_webx_static::decl()],
+//         esm_files: include_js_files!(stdlib "src/engine/stdlib.js",)
+//             .to_vec()
+//             .into(),
+//         ..Default::default()
+//     }
+// }
 
 pub const JAVASCRIPT: &str = include_str!("./stdlib.js");

--- a/src/file/webx.rs
+++ b/src/file/webx.rs
@@ -247,61 +247,17 @@ impl Debug for WXRouteReqBody {
     }
 }
 
-/// Literal values in WebX.
-#[derive(Debug, Hash, PartialEq, Eq, Clone)]
-pub enum WXLiteralValue {
-    Identifier(String),
-    String(String),
-    /// Number(integer, decimal)
-    Number(u32, u32),
-    Boolean(bool),
-    Null,
-    Array(Vec<WXLiteralValue>),
-    Object(Vec<(String, WXLiteralValue)>),
-}
-
-impl Display for WXLiteralValue {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            WXLiteralValue::Identifier(name) => write!(f, "{}", name),
-            WXLiteralValue::String(string) => write!(f, "\"{}\"", string),
-            WXLiteralValue::Number(integer, decimal) => write!(f, "{}.{}", integer, decimal),
-            WXLiteralValue::Boolean(boolean) => write!(f, "{}", boolean),
-            WXLiteralValue::Null => write!(f, "null"),
-            WXLiteralValue::Array(array) => {
-                write!(f, "[")?;
-                for (i, value) in array.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{}", value)?;
-                }
-                write!(f, "]")
-            }
-            WXLiteralValue::Object(object) => {
-                write!(f, "{{")?;
-                for (i, (key, value)) in object.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "{}: {}", key, value)?;
-                }
-                write!(f, "}}")
-            }
-        }
-    }
-}
-
 #[derive(Hash, PartialEq, Eq, Clone)]
-pub struct WXRouteHandler {
+pub struct WXRouteHandlerCall {
     pub name: String,
-    pub args: Vec<String>,
+    /// Evaluate wrapped in [] to allow for empty arguments.
+    pub args: String,
     pub output: Option<String>,
 }
 
-impl fmt::Debug for WXRouteHandler {
+impl fmt::Debug for WXRouteHandlerCall {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}({})", self.name, self.args.join(", "))?;
+        write!(f, "{}({})", self.name, self.args)?;
         if let Some(output) = &self.output {
             write!(f, ": {}", output)?;
         }
@@ -319,11 +275,11 @@ pub struct WXRoute {
     /// Request body format.
     pub body_format: Option<WXRouteReqBody>,
     /// The pre-handler functions of the route.
-    pub pre_handlers: Vec<WXRouteHandler>,
+    pub pre_handlers: Vec<WXRouteHandlerCall>,
     /// The code block of the route.
     pub body: Option<WXBody>,
     /// The post-handler functions of the route.
-    pub post_handlers: Vec<WXRouteHandler>,
+    pub post_handlers: Vec<WXRouteHandlerCall>,
 }
 
 impl Hash for WXRoute {

--- a/src/reporting/debug.rs
+++ b/src/reporting/debug.rs
@@ -4,7 +4,7 @@ use colored::Colorize;
 use crate::runner::WXMode;
 
 pub fn info(mode: WXMode, text: &str) {
-    if mode.is_dev() && mode.debug_level().is_high() {
+    if mode.is_dev() && mode.debug_level().is_medium() {
         let now = Local::now();
         let time = now.format("%d/%m %H:%M:%S");
         let prefix = format!("[Info {}]", time);

--- a/src/reporting/debug.rs
+++ b/src/reporting/debug.rs
@@ -7,7 +7,7 @@ pub fn info(mode: WXMode, text: &str) {
     if mode.is_dev() && mode.debug_level().is_medium() {
         let now = Local::now();
         let time = now.format("%d/%m %H:%M:%S");
-        let prefix = format!("[Info {}]", time);
+        let prefix = format!("Info (T{})", time);
         println!("{}: {}", prefix.bright_cyan(), text);
     }
 }

--- a/src/reporting/error.rs
+++ b/src/reporting/error.rs
@@ -12,6 +12,7 @@ pub const ERROR_SYNTAX: i32 = 5;
 pub const ERROR_DUPLICATE_ROUTE: i32 = 6;
 pub const ERROR_INVALID_ROUTE: i32 = 7;
 pub const ERROR_HANDLER_CALL: i32 = 8;
+pub const ERROR_EXEC_ROUTE: i32 = 9;
 
 pub fn code_to_name(code: i32) -> String {
     match code {
@@ -20,6 +21,7 @@ pub fn code_to_name(code: i32) -> String {
         ERROR_CIRCULAR_DEPENDENCY => "Circular Dependency".to_owned(),
         ERROR_DUPLICATE_ROUTE => "Duplicate Route".to_owned(),
         ERROR_INVALID_ROUTE => "Invalid Route".to_owned(),
+        ERROR_EXEC_ROUTE => "Execute Route".to_owned(),
         ERROR_HANDLER_CALL => "Handler Call".to_owned(),
         ERROR_PARSE_IO => "Parse IO".to_owned(),
         ERROR_SYNTAX => "Syntax".to_owned(),

--- a/src/reporting/warning.rs
+++ b/src/reporting/warning.rs
@@ -4,7 +4,7 @@ use colored::*;
 use crate::runner::WXMode;
 
 fn warning_generic(mode: WXMode, message: String, warning_name: &str) {
-    if mode.is_dev() && mode.debug_level().is_medium() {
+    if mode.is_dev() && mode.debug_level().is_high() {
         eprintln!("{}: {}", warning_name.yellow(), message);
     }
 }
@@ -12,5 +12,5 @@ fn warning_generic(mode: WXMode, message: String, warning_name: &str) {
 pub fn warning(mode: WXMode, message: String) {
     let now = Local::now();
     let time = now.format("%d/%m %H:%M:%S");
-    warning_generic(mode, message, format!("[Warn {}]", time).as_str());
+    warning_generic(mode, message, format!("Warn (T{})", time).as_str());
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -88,6 +88,14 @@ impl WXMode {
             _ => DebugLevel::Low,
         }
     }
+
+    pub fn date_specifier(&self) -> DateTimeSpecifier {
+        if self.debug_level().is_high() {
+            DateTimeSpecifier::Verbose
+        } else {
+            DateTimeSpecifier::Short
+        }
+    }
 }
 
 //* Implement PartialEq for WXMode without taking DebugLevel into account

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -14,6 +14,7 @@ use crate::engine::server::WXServer;
 use crate::file::project::{load_modules, load_project_config, ProjectConfig};
 use crate::file::webx::WXModule;
 use crate::reporting::error::{exit_error_hint, DateTimeSpecifier, ERROR_PROJECT};
+use crate::reporting::warning::warning;
 
 pub fn get_project_config_file_path(root: &Path) -> PathBuf {
     root.join("webx.config.json")
@@ -239,8 +240,12 @@ pub fn run(root: &Path, mode: WXMode, running: Arc<AtomicBool>) {
         let sv_rt_tx = rt_tx.clone();
         let mut server = WXServer::new(mode, config, sv_rt_tx);
         server.run(running).expect("Failed to run server");
-        runtime_hnd.join().unwrap();
-        fw_hnd.join().unwrap();
+        if runtime_hnd.join().is_err() {
+            warning(mode, "Failed to stop runtime".into());
+        }
+        if fw_hnd.join().is_err() {
+            warning(mode, "Failed to stop file watcher".into())
+        }
     } else {
         // If we are in production mode, run the `server` in main thread.
         let info = WXRuntimeInfo::new(root);
@@ -253,7 +258,9 @@ pub fn run(root: &Path, mode: WXMode, running: Arc<AtomicBool>) {
         let sv_rt_tx = rt_tx.clone();
         let mut server = WXServer::new(mode, config, sv_rt_tx);
         server.run(running).expect("Failed to run server");
-        runtime_hnd.join().unwrap();
+        if runtime_hnd.join().is_err() {
+            warning(mode, "Failed to stop runtime".into())
+        }
     }
     // Check ps info: `ps | ? ProcessName -eq "webx"`
     // On interrupt, all threads are also terminated


### PR DESCRIPTION
Description:
This pull request addresses some of the following changes:
- Use JS-only values to improve consistent user experience
- Resolved a minor bug in the existing code
- Removed site manifest link
- Explicit public assets route
- Moved about
- Fixed variable creation in runtime isolate scope instead of temporary
- Implemented the rest of the route execution
- Removed init temporarily
- Handled potential errors
- Added execute route error
- Fixed warning and info formats
- Warned when failing to close threads
- Fix execute routes
- Fix webx_static
- Add ok_json response
- Use Bytes responses
- Ignore empty messages
- Fix server header and banner
- Improve banner and header handling
- Generic body
- Remove `WXLiteralValue`

This change has been tested locally and is ready to be reviewed.